### PR TITLE
Fix Cannot read property 'destroy' of undefined

### DIFF
--- a/src/image-picker.js
+++ b/src/image-picker.js
@@ -84,7 +84,9 @@ function init(Survey, $) {
     },
     willUnmount: function(question, el) {
       var $el = $(el).find("select");
-      $el.data("picker").destroy();
+      if ($el.data("picker")) {
+        $el.data("picker").destroy();
+      }
     }
   };
 


### PR DESCRIPTION
After the fix for https://github.com/surveyjs/widgets/issues/45 was merged, display mode works great (thanks!) However, I am seeing this error happen if my survey is in display mode when the component unmounts (eg. if I go to a different page.)

This should fix it, although maybe this is just a "bandaid" to the real problem.

![image](https://user-images.githubusercontent.com/10538978/39080081-d86d6cd0-44e4-11e8-80a7-66dbdcf1e826.png)
