### PR TITLE
Improve noUiSlider styling

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -60,9 +60,9 @@ function init(Survey) {
     },
     afterRender: function (question, el) {
       el.style.paddingBottom = "19px";
-      el.style.paddingRight = "30px";
+      el.style.paddingLeft = "20px";
+      el.style.paddingRight = "20px";
       el.style.paddingTop = "44px";
-      el.style.width = "95%";
       el = el.children[0];
       el.style.marginBottom = "60px";
       if (question.orientation === "vertical") {


### PR DESCRIPTION
I had a bit of trouble with the noUiSlider widget in certain situations, where the slider wouldn't fit entirely into its parent container and a scrollbar would be displayed at the bottom:

<img width="500" alt="Screenshot 2020-06-13 at 11 29 28" src="https://user-images.githubusercontent.com/2046265/84565502-df6f3500-ad69-11ea-8845-59f3811d6798.png">

I solved this by slightly changing the styling: instead of using a width of 95% and adding a wide padding on the right (which, in this combination, was the culprit of my issue seen in the screenshot above), I don't specify a width anymore and add a bit of padding on both the left and right side to have enough space for the slider to be dragged all the way to the sides.

This change also improves the overall appearance of questions using this widget, as the slider is now – at least in my case – centered below the question, i.e. its appearance is more symmetrical.

After the change:
<img width="500" alt="Screenshot 2020-06-13 at 11 26 13" src="https://user-images.githubusercontent.com/2046265/84565521-075e9880-ad6a-11ea-8710-960def6ca3ea.png">
