### PR TITLE
BF: Pass $ to bootstrap-datepicker widget's init()

### DIFF
--- a/src/bootstrapdatepicker.js
+++ b/src/bootstrapdatepicker.js
@@ -1,4 +1,6 @@
-function init(Survey) {
+function init(Survey, $) {
+    $ = $ || window.$;
+
     if (!$.fn.bootstrapDP && !!$.fn.datepicker && !!$.fn.datepicker.noConflict) {
         $.fn.bootstrapDP = $.fn.datepicker.noConflict();
         if (!$.fn.datepicker) {


### PR DESCRIPTION
At the bottom of the module, `init()` is invoked via: `init(Survey, window.$);`; however, the `init()` function doesn't accept the second argument. This commit fixes this, and automatically uses `window.$` if no `$` was passed.