### PR TITLE
Expose  more settings of bootstrap-datepicker

### DIFF
--- a/src/bootstrapdatepicker.js
+++ b/src/bootstrapdatepicker.js
@@ -35,10 +35,14 @@ function init(Survey) {
                     default: "'mm/dd/yyyy'"
                 },
                 {
+                    // Can take a Date or a string
+                    // https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#options
                     name: "startDate",
                     default: ""
                 },
                 {
+                    // Can take a Date or a string
+                    // https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#options
                     name: "endDate",
                     default: ""
                 },

--- a/src/bootstrapdatepicker.js
+++ b/src/bootstrapdatepicker.js
@@ -31,6 +31,7 @@ function init(Survey) {
             Survey.JsonObject.metaData.addProperties("bootstrapdatepicker", [
                 {
                     // Can take a string or an Object.
+                    // https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format
                     name: "dateFormat",
                     default: "'mm/dd/yyyy'"
                 },

--- a/src/bootstrapdatepicker.js
+++ b/src/bootstrapdatepicker.js
@@ -28,9 +28,45 @@ function init(Survey) {
                 null,
                 "text"
             );
-            Survey.JsonObject.metaData.addProperty("bootstrapdatepicker", {
-                name: "dateFormat"
-            });
+            Survey.JsonObject.metaData.addProperties("bootstrapdatepicker", [
+                {
+                    // Can take a string or an Object.
+                    name: "dateFormat",
+                    default: "'mm/dd/yyyy'"
+                },
+                {
+                    name: "startDate",
+                    default: ""
+                },
+                {
+                    name: "endDate",
+                    default: ""
+                },
+                {
+                    name: "todayHighlight:boolean",
+                    default: true,
+                },
+                {
+                    name: "weekStart:number",
+                    default: 0
+                },
+                {
+                    name: "clearBtn:boolean",
+                    default: false
+                },
+                {
+                    name: "autoClose:boolean",
+                    default: true,
+                },
+                {
+                    name: "daysOfWeekHighlighted:string",
+                    default: ""
+                },
+                {
+                    name: "disableTouchKeyboard:boolean",
+                    default: true
+                }
+            ]);
         },
         afterRender: function (question, el) {
             var $el = $(el).is(".widget-datepicker")
@@ -38,7 +74,16 @@ function init(Survey) {
                 : $(el).find(".widget-datepicker");
 
             var pickerWidget = $el.bootstrapDP({
-                enableOnReadonly: false
+                enableOnReadonly: false,
+                format: question.dateFormat,
+                startDate: question.startDate,
+                endDate: question.endDate,
+                todayHighlight: question.todayHighlight,
+                weekStart: question.weekStart,
+                clearBtn: question.clearBtn,
+                autoclose: question.autoClose,
+                daysOfWeekHighlighted: question.daysOfWeekHighlighted,
+                disableTouchKeyboard: question.disableTouchKeyboard
             })
             // .on("changeDate", function (e) {
             //     question.value = moment(e.date).format("DD/MM/YYYY");


### PR DESCRIPTION
This PR adds support for a number of additional configuration options of the bootstrap-datepicker. It also fixes handling of the `dateFormat` option, which was previously ignored.

Here is an example of what it can look like. Notice the shaded weekends, the highlighted "today" date, the disabled future dates, and the "Clear" button at the bottom. All of these are optional, of course.

<img width="290" alt="Screenshot 2020-06-14 at 22 30 42" src="https://user-images.githubusercontent.com/2046265/84603435-bd230780-ae8e-11ea-8844-68ffc4cd6758.png">
