### PR TITLE
nouislider: Added decimals option

### DIFF
--- a/src/nouislider.js
+++ b/src/nouislider.js
@@ -56,6 +56,10 @@ function init(Survey) {
           name: "tooltips:boolean",
           default: true,
         },
+        {
+          name: "decimals:number",
+          default: 2,
+        },
       ]);
     },
     afterRender: function (question, el) {
@@ -94,6 +98,14 @@ function init(Survey) {
               return pipText;
             },
           },
+        },
+        format: {
+          to: function ( value ) {
+            return Number(value).toFixed(question.decimals);
+          },
+          from: function ( value ) {
+            return Number(value).toFixed(question.decimals);
+          }
         },
         range: {
           min: question.rangeMin,


### PR DESCRIPTION
I have added the `decimals` option to set the desired number of decimal places. It defaults to 2, which is the default value for nouisliders. This means that this change is not code-breaking.

- If you set `decimals` to 0, the decimal places are completely removed. This is useful if `step` is an integer.
- If you set `decimals` to 1, you get one decimal place. This only makes sense if `step` is a floating point number. Otherwise you could not select such numbers.

Fixes #165 
